### PR TITLE
Fix command recognition bug

### DIFF
--- a/python/led_ia_voz.py
+++ b/python/led_ia_voz.py
@@ -12,10 +12,12 @@ def enviar_comando_para_esp32(comando):
 
 def interpretar_comando(comando):
     comando = comando.lower()
-    if "ligar" in comando or "acender" in comando:
-        return "ligar"
-    elif "desligar" in comando or "apagar" in comando:
+    # Verifica primeiro por "desligar" para evitar que a palavra
+    # "ligar" contida em "desligar" cause interpretação incorreta
+    if "desligar" in comando or "apagar" in comando:
         return "desligar"
+    elif "ligar" in comando or "acender" in comando:
+        return "ligar"
     else:
         return "comando_desconhecido"
 

--- a/python/led_ia_voz_fala.py
+++ b/python/led_ia_voz_fala.py
@@ -26,10 +26,12 @@ def enviar_comando_para_esp32(comando):
 
 def interpretar_comando(texto):
     texto = texto.lower()
-    if "ligar" in texto or "acender" in texto:
-        return "ligar"
-    elif "desligar" in texto or "apagar" in texto:
+    # Verifica primeiro se o usuário quer desligar para evitar falso positivo
+    # com a substring "ligar" dentro de "desligar".
+    if "desligar" in texto or "apagar" in texto:
         return "desligar"
+    elif "ligar" in texto or "acender" in texto:
+        return "ligar"
     else:
         return "comando_desconhecido"
 

--- a/python/led_ia_voz_log.py
+++ b/python/led_ia_voz_log.py
@@ -17,10 +17,12 @@ def enviar_comando_para_esp32(comando):
 
 def interpretar_comando(texto):
     texto = texto.lower()
-    if "ligar" in texto or "acender" in texto:
-        return "ligar"
-    elif "desligar" in texto or "apagar" in texto:
+    # A palavra "ligar" está contida em "desligar". Para evitar erro,
+    # checamos "desligar" antes de procurar por "ligar" ou "acender".
+    if "desligar" in texto or "apagar" in texto:
         return "desligar"
+    elif "ligar" in texto or "acender" in texto:
+        return "ligar"
     else:
         return "comando_desconhecido"
 


### PR DESCRIPTION
## Summary
- avoid interpreting `desligar` as `ligar` in voice scripts

## Testing
- `python -m py_compile python/*.py && echo "py_compile success"`


------
https://chatgpt.com/codex/tasks/task_e_6841eded39408323927cbe6b4e550a02